### PR TITLE
Make theme submodule use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/learn"]
 	path = themes/learn
-	url = git@github.com:matcornic/hugo-theme-learn.git
+	url = https://github.com/matcornic/hugo-theme-learn.git


### PR DESCRIPTION
Netlify trips up over ssh submodules. This change our theme submodule to https. Should be the same either way since it's a public repo.